### PR TITLE
Fix CARLA traffic light matching and document rmw_zenoh usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,26 +70,38 @@ colcon build --symlink-install
 ./CarlaUE4.sh -quality-level=Epic -world-port=2000 -RenderOffScreen -prefernvidia
 ```
 
+- Pick one mode and use the matching script in every step below:
+  - `rmw_zenoh`: use `rmw_zenoh_cpp` directly as the RMW.
+  - `ros2dds`: use `rmw_cyclonedds_cpp` with `zenoh-bridge-ros2dds`.
+
 - In bridge container
 
 ```shell
 # Run zenoh_carla_bridge, Python Agent and V2X module
 cd autoware_carla_launch
 source env.sh
+# Option A: rmw_zenoh
+./script/bridge_rmw_zenoh/run-bridge-v2x-with-rmw_zenoh.sh
+# Option B: ros2dds
 ./script/bridge_ros2dds/run-bridge-v2x.sh
 ```
 
 - In Autoware container
 
 ```shell
-# Run zenoh-bridge-ros2dds and Autoware
+# Run Autoware
 cd autoware_carla_launch
 source env.sh
+# Option A: rmw_zenoh
+./script/autoware_rmw_zenoh/run-autoware-with-rmw_zenoh.sh
+# Option B: ros2dds
 ./script/autoware_ros2dds/run-autoware.sh
 
 # Open another window in the Autoware container to execute the commands below.
-source external/zenoh_autoware_v2x/install/setup.bash
-ros2 run v2x_light v2x_light -- -v <vehicle_ID>
+# Option A: rmw_zenoh
+./script/autoware_rmw_zenoh/run-v2x-light-with-rmw_zenoh.sh <vehicle_ID>
+# Option B: ros2dds
+./script/autoware_ros2dds/run-v2x-light.sh <vehicle_ID>
 ```
 
 **Note:** <vehicle_ID> must match the CARLA agent's role name. (default is "v1")

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ The `map_info.json` file defines the mapping between intersections and traffic l
 - Each intersection includes traffic lights that influence each other’s traffic flow, meaning that simultaneous green lights could create conflicts.
   - **`autoware_lane`**: Corresponding lane ID in Autoware.
   - **`autoware_traffic_light`**: Traffic light ID in Autoware.
-  - **`carla_traffic_light`**: Traffic light ID in the CARLA simulator.
   - **`traffic_light_position`**:
     - The traffic light's position in Autoware's coordinate system (`x, y`).
+    - The Intersection Manager matches each entry to the nearest CARLA traffic light actor by this position at startup.
     - **Coordinate system transformation**:
       - The x-axis in Autoware and CARLA are the same.
       - The y-axis in Autoware is the inverse of CARLA’s y-axis (`Autoware_y = -CARLA_y`).
@@ -116,12 +116,9 @@ The `map_info.json` file defines the mapping between intersections and traffic l
   - The `lanelet2_map.osm` file can be imported into [Tier IV Vector Map Builder](https://tools.tier4.jp/feature/vector_map_builder_ll2/) to obtain lane IDs and traffic light IDs.
   - In **Autoware version 20240903**, traffic light IDs can also be identified from the RViz-rendered map.
 
-- **`carla_traffic_light`**:
-  - Can be retrieved using the CARLA API which will return a list of traffic light actors.
-
 - **`traffic_light_position`**:
   - The position of traffic lights can be obtained using the CARLA API.
-    The Carla coordinate y-axis value should be negated to match Autoware’s coordinate system.
+    The CARLA coordinate y-axis value should be negated to match Autoware’s coordinate system.
   - Alternatively, positions can also be extracted from the `lanelet2_map.osm` file.
 
 The `map_info.json` file is loaded during the initialization of the **Traffic Manager** and **Intersection Manager**.

--- a/autoware_v2x/src/v2x_light/v2x_light/v2x_light.py
+++ b/autoware_v2x/src/v2x_light/v2x_light/v2x_light.py
@@ -6,10 +6,10 @@ from enum import Enum
 import rclpy
 import zenoh
 from autoware_adapi_v1_msgs.msg import VehicleKinematics
+from autoware_internal_planning_msgs.msg import PathWithLaneId
 from autoware_perception_msgs.msg import TrafficLightElement, TrafficLightGroup, TrafficLightGroupArray
 from rclpy.node import Node
 from rclpy.qos import QoSProfile
-from tier4_planning_msgs.msg import PathWithLaneId
 from zenoh import Config, QueryTarget, Reliability
 
 """

--- a/intersection_manager/main.py
+++ b/intersection_manager/main.py
@@ -10,6 +10,9 @@ import zenoh
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 
+# Max distance (meters) between a map_info.json position and a CARLA traffic light actor.
+TRAFFIC_LIGHT_MATCH_THRESHOLD_M = 5.0
+
 
 def trace(func):
     if asyncio.iscoroutinefunction(func):
@@ -40,32 +43,48 @@ def trace(func):
 
 
 class Intersection:
-    def __init__(self, section_id, light_mapping):
+    def __init__(self, section_id, light_positions):
         self.section_id = section_id
-        self.light_mapping = light_mapping
-        self.traffic_lights = self._filter_traffic_lights()
+        # {autoware_tl: (carla_x, carla_y)} — CARLA-frame positions
+        self.light_positions = light_positions
+        self.traffic_lights = self._match_traffic_lights()
         # self.priority_event = threading.Event()
         self.priority_event = asyncio.Event()
 
-    def _filter_traffic_lights(self):
-        """Retrieve specific Carla traffic lights based on IDs."""
+    def _match_traffic_lights(self):
+        """Resolve each autoware traffic light to the nearest CARLA actor by position.
+
+        CARLA actor IDs aren't stable across versions/sessions, so we match by world
+        coordinates instead of relying on a hard-coded id field in map_info.json.
+        """
         traffic_lights = {}
-        for actor in world_traffic_lights:
-            if actor.id in self.light_mapping.values():
-                traffic_lights[actor.id] = actor
-        for key, carla_item in traffic_lights.items():
-            logging.debug(f'[Intersection Manager] Traffic Light ID {key} is getted.')
+        for autoware_tl, (x, y) in self.light_positions.items():
+            best = min(
+                world_traffic_lights,
+                key=lambda a, x=x, y=y: (a.get_location().x - x) ** 2 + (a.get_location().y - y) ** 2,
+            )
+            loc = best.get_location()
+            dist = ((loc.x - x) ** 2 + (loc.y - y) ** 2) ** 0.5
+            if dist > TRAFFIC_LIGHT_MATCH_THRESHOLD_M:
+                logging.warning(
+                    f'[Intersection Manager][{self.section_id}] autoware_tl {autoware_tl}: '
+                    f'nearest CARLA light id={best.id} is {dist:.2f}m away '
+                    f'(threshold {TRAFFIC_LIGHT_MATCH_THRESHOLD_M}m) — check map_info.json'
+                )
+            else:
+                logging.debug(f'[Intersection Manager][{self.section_id}] autoware_tl {autoware_tl} -> CARLA id={best.id} (dist={dist:.2f}m)')
+            traffic_lights[autoware_tl] = best
         return traffic_lights
 
     def _set_traffic_light_state(self, green_id):
         """Set traffic light states: one green, others red."""
-        for id, traffic_light in self.traffic_lights.items():
-            if id == green_id:
+        for autoware_tl, traffic_light in self.traffic_lights.items():
+            if autoware_tl == green_id:
                 traffic_light.set_state(carla.TrafficLightState.Green)
-                logging.debug(f'[Intersection Manager][{self.section_id}] Traffic light {id} set to GREEN')
+                logging.debug(f'[Intersection Manager][{self.section_id}] Traffic light {autoware_tl} set to GREEN')
             else:
                 traffic_light.set_state(carla.TrafficLightState.Red)
-                logging.debug(f'[Intersection Manager][{self.section_id}] Traffic light {id} set to RED')
+                logging.debug(f'[Intersection Manager][{self.section_id}] Traffic light {autoware_tl} set to RED')
 
     @trace
     async def auto_changing_state(self):
@@ -83,19 +102,17 @@ class Intersection:
 
     @trace
     def get_state(self, autoware_tl):
-        carla_tl = self.light_mapping[autoware_tl]
-        return self.traffic_lights[carla_tl].get_state()
+        return self.traffic_lights[autoware_tl].get_state()
 
     @trace
     async def handle_priority(self, autoware_tl, duration):
         self.priority_event.set()
         logging.info(f'[Intersection Manager][{self.section_id}] Priority active, priority event is set.')
-        carla_tl = self.light_mapping[autoware_tl]
-        for id, traffic_light in self.traffic_lights.items():
-            if id != carla_tl:
+        for tl_id, traffic_light in self.traffic_lights.items():
+            if tl_id != autoware_tl:
                 traffic_light.set_state(carla.TrafficLightState.Red)
         await asyncio.sleep(1)
-        self.traffic_lights[carla_tl].set_state(carla.TrafficLightState.Green)
+        self.traffic_lights[autoware_tl].set_state(carla.TrafficLightState.Green)
         if duration != 0:
             await asyncio.sleep(duration)
             self.priority_event.clear()
@@ -107,12 +124,23 @@ class Intersection:
 
 
 def load_map_info(file_path):
+    """Load {section_id: {autoware_tl: (carla_x, carla_y)}} from map_info.json.
+
+    map_info.json stores positions in Autoware coordinates (Autoware_y = -CARLA_y),
+    so we negate y here to keep the rest of the code in CARLA's frame.
+    """
     with open(file_path, 'r') as f:
         map_info = json.load(f)
-    autoware_to_carla_tl = {}
+    autoware_to_position = {}
     for section_id, lanes in map_info['intersections'].items():
-        autoware_to_carla_tl[section_id] = {int(lane['autoware_traffic_light']): int(lane['carla_traffic_light']) for lane in lanes}
-    return autoware_to_carla_tl
+        autoware_to_position[section_id] = {
+            int(lane['autoware_traffic_light']): (
+                float(lane['traffic_light_position']['x']),
+                -float(lane['traffic_light_position']['y']),
+            )
+            for lane in lanes
+        }
+    return autoware_to_position
 
 
 @trace
@@ -246,7 +274,7 @@ if __name__ == '__main__':
     fix_red_light_to_all()
 
     intersections = {}
-    for section_id, light_mapping in map_info.items():
-        intersections[section_id] = Intersection(section_id, light_mapping)
+    for section_id, light_positions in map_info.items():
+        intersections[section_id] = Intersection(section_id, light_positions)
 
     asyncio.run(main())

--- a/map_info.json
+++ b/map_info.json
@@ -4,7 +4,6 @@
             {
                 "autoware_lane": 25355,
                 "autoware_traffic_light": 29855,
-                "carla_traffic_light": 27,
                 "traffic_light_position": {
                     "x": 85.729996,
                     "y": -45.779999
@@ -13,7 +12,6 @@
             {
                 "autoware_lane": 21186,
                 "autoware_traffic_light": 29777,
-                "carla_traffic_light": 26,
                 "traffic_light_position": {
                     "x": 102.720001,
                     "y": -52.850018
@@ -22,7 +20,6 @@
             {
                 "autoware_lane": 25648,
                 "autoware_traffic_light": 29861,
-                "carla_traffic_light": 25,
                 "traffic_light_position": {
                     "x": 94.989975,
                     "y": -70.409996
@@ -33,7 +30,6 @@
             {
                 "autoware_lane": 21093,
                 "autoware_traffic_light": 29783,
-                "carla_traffic_light": 42,
                 "traffic_light_position": {
                     "x": 144.240036,
                     "y": -62.289997
@@ -42,7 +38,6 @@
             {
                 "autoware_lane": 26359,
                 "autoware_traffic_light": 29903,
-                "carla_traffic_light": 41,
                 "traffic_light_position": {
                     "x": 151.309952,
                     "y": -45.300076
@@ -51,7 +46,6 @@
             {
                 "autoware_lane": 21828,
                 "autoware_traffic_light": 29789,
-                "carla_traffic_light": 40,
                 "traffic_light_position": {
                     "x": 168.869995,
                     "y": -53.030037
@@ -62,7 +56,6 @@
             {
                 "autoware_lane": 24578,
                 "autoware_traffic_light": 29825,
-                "carla_traffic_light": 47,
                 "traffic_light_position": {
                     "x": 341.250031,
                     "y": -69.509956
@@ -71,7 +64,6 @@
             {
                 "autoware_lane": 21507,
                 "autoware_traffic_light": 29795,
-                "carla_traffic_light": 44,
                 "traffic_light_position": {
                     "x": 321.760101,
                     "y": -62.440075
@@ -80,7 +72,6 @@
             {
                 "autoware_lane": 24283,
                 "autoware_traffic_light": 29819,
-                "carla_traffic_light": 43,
                 "traffic_light_position": {
                     "x": 331.990021,
                     "y": -44.880039
@@ -91,7 +82,6 @@
             {
                 "autoware_lane": 25539,
                 "autoware_traffic_light": 29867,
-                "carla_traffic_light": 30,
                 "traffic_light_position": {
                     "x": 85.729988,
                     "y": -119.75
@@ -100,7 +90,6 @@
             {
                 "autoware_lane": 18400,
                 "autoware_traffic_light": 29741,
-                "carla_traffic_light": 29,
                 "traffic_light_position": {
                     "x": 102.719986,
                     "y": -126.820015
@@ -109,7 +98,6 @@
             {
                 "autoware_lane": 25838,
                 "autoware_traffic_light": 29873,
-                "carla_traffic_light": 28,
                 "traffic_light_position": {
                     "x": 94.989967,
                     "y": -144.38002
@@ -120,7 +108,6 @@
             {
                 "autoware_lane": 24756,
                 "autoware_traffic_light": 29927,
-                "carla_traffic_light": 50,
                 "traffic_light_position": {
                     "x": 341.250031,
                     "y": -143.559952
@@ -129,7 +116,6 @@
             {
                 "autoware_lane": 17947,
                 "autoware_traffic_light": 29747,
-                "carla_traffic_light": 49,
                 "traffic_light_position": {
                     "x": 321.680115,
                     "y": -136.132156
@@ -138,7 +124,6 @@
             {
                 "autoware_lane": 24469,
                 "autoware_traffic_light": 29831,
-                "carla_traffic_light": 48,
                 "traffic_light_position": {
                     "x": 331.990021,
                     "y": -118.930038
@@ -149,7 +134,6 @@
             {
                 "autoware_lane": 25743,
                 "autoware_traffic_light": 29879,
-                "carla_traffic_light": 33,
                 "traffic_light_position": {
                     "x": 85.729988,
                     "y": -185.289993
@@ -158,7 +142,6 @@
             {
                 "autoware_lane": 22808,
                 "autoware_traffic_light": 29801,
-                "carla_traffic_light": 32,
                 "traffic_light_position": {
                     "x": 102.719986,
                     "y": -192.550003
@@ -167,7 +150,6 @@
             {
                 "autoware_lane": 26284,
                 "autoware_traffic_light": 29885,
-                "carla_traffic_light": 31,
                 "traffic_light_position": {
                     "x": 94.989967,
                     "y": -209.919998
@@ -178,7 +160,6 @@
             {
                 "autoware_lane": 25202,
                 "autoware_traffic_light": 29921,
-                "carla_traffic_light": 53,
                 "traffic_light_position": {
                     "x": 341.250031,
                     "y": -209.09996
@@ -187,7 +168,6 @@
             {
                 "autoware_lane": 22355,
                 "autoware_traffic_light": 29807,
-                "carla_traffic_light": 52,
                 "traffic_light_position": {
                     "x": 323.410095,
                     "y": -202.030075
@@ -196,7 +176,6 @@
             {
                 "autoware_lane": 24667,
                 "autoware_traffic_light": 29837,
-                "carla_traffic_light": 51,
                 "traffic_light_position": {
                     "x": 331.990021,
                     "y": -184.470032

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,21 +18,25 @@ files = [
 
 [[package]]
 name = "eclipse-zenoh"
-version = "1.0.2"
-description = "The python API for Eclipse zenoh"
+version = "1.8.0"
+description = "The Zenoh Python API"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "eclipse_zenoh-1.0.2-cp38-abi3-linux_armv6l.whl", hash = "sha256:86eb01b0df57d4532f8f045f464f4277bdc54bf7e318b5a1f15c1432f3bd8279"},
-    {file = "eclipse_zenoh-1.0.2-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:652f904badc6904a1000e45b3f73932efb098538934f5bdff89348e7b41a51a1"},
-    {file = "eclipse_zenoh-1.0.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:cb57ebcf27f4a599972d7060f35545d65bd5c8372aa05e18cc0b2f2e573564cf"},
-    {file = "eclipse_zenoh-1.0.2-cp38-abi3-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e5d21185ab86b3cb9dcbe177d2f55654434f3eca6227db0afad5e5e3405867df"},
-    {file = "eclipse_zenoh-1.0.2-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:187c9dc1713c22607de21afe1f0e9fdd49890ef5ebd1e9d941f3af7f000f375d"},
-    {file = "eclipse_zenoh-1.0.2-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cf0bd52390c35f7fd1d9ccba44094d8a8341c72910cb4f01e55209bd3d75b0e1"},
-    {file = "eclipse_zenoh-1.0.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:971496374df46fe34eb38dca080ca05022b7c459c3e59af2629b570438e170ec"},
-    {file = "eclipse_zenoh-1.0.2-cp38-abi3-win_amd64.whl", hash = "sha256:07aa7e1a2c584ac0d362d69938e374de28fd4e6766a0f23999899a2976a00df0"},
-    {file = "eclipse_zenoh-1.0.2.tar.gz", hash = "sha256:796cd2d0b5ef727351f486d802ca6d313346095cc40f28dc6cd3a924e24a09f5"},
+    {file = "eclipse_zenoh-1.8.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:07fa53f31e53a60136cdaf78a831a812d8b442790d1bb3900cf50b660f157208"},
+    {file = "eclipse_zenoh-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3293189039f5ba013881bca2102277a12988d7fbd9755eb15d8844fdca120355"},
+    {file = "eclipse_zenoh-1.8.0-cp39-abi3-linux_armv6l.whl", hash = "sha256:b09657978c22e75ccc52a245665c88caea98948e7d961c0e57567d405001f716"},
+    {file = "eclipse_zenoh-1.8.0-cp39-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:54297b9bb519974aaf318a5fef0f35101730143e53b334464b1c1cf536ec2080"},
+    {file = "eclipse_zenoh-1.8.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4d1a12246d592ee86accf58d35967e12a35f2efca85b46dee90fc61831ce0d4e"},
+    {file = "eclipse_zenoh-1.8.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ca624399b154a52fad3c466e91f02af018b002adb6f19e8b00abc1c0c94209d8"},
+    {file = "eclipse_zenoh-1.8.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1aca875fd5aa38284cf7161964241a73b4e4090a48385c35a6d8e6169cc8e88a"},
+    {file = "eclipse_zenoh-1.8.0-cp39-abi3-win_amd64.whl", hash = "sha256:2eb1778bff7b92b8af2cc6ee0c5ac14fa0f84019e3dafc593cdd44f003fb5aac"},
+    {file = "eclipse_zenoh-1.8.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6c98ae7097b4cd5239176342c8d922e78c2715d8d49d77f4a559f20921e5eff3"},
+    {file = "eclipse_zenoh-1.8.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:ea36a793091d987d5da3106ec835a696fdd3431488f4eec9812e660b1fcfe0e8"},
+    {file = "eclipse_zenoh-1.8.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d688c9a4712f17ffb4bef2a1bea0c7dba838a62876054900662bd13dae9c455d"},
+    {file = "eclipse_zenoh-1.8.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:aba37e2447785aa822ca07096e577bac8a5afad5738a3bc20710d4015360adfa"},
+    {file = "eclipse_zenoh-1.8.0.tar.gz", hash = "sha256:1cb0b8abdc522d58497c0cd7b8c8e7791f39d2c189c5e0bc80da8840af0ce24d"},
 ]
 
 [[package]]
@@ -154,4 +158,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "cb8c66dec2e7708f282e15d6253688ffd03bef406c09facf8f8a2795687a795f"
+content-hash = "73d3471c839b5424916521a6bd76f2c7869cdf2cbd9187fb7dcfe4045978fb52"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = "^3.12"
 pygame = "^2.1.2"
 carla = "0.9.16"
 numpy = "^1.26"
-eclipse-zenoh = "1.0.2"
+eclipse-zenoh = "1.8.0"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR includes two updates:
- Match CARLA traffic lights by position instead of hard-coded actor IDs.
- Add README instructions for running with `rmw_zenoh` or `ros2dds`.